### PR TITLE
:fire: remove required depedency on font awesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,7 +1015,8 @@
     "@fortawesome/fontawesome-free": {
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.2.tgz",
-      "integrity": "sha512-E4fDUF4fbu9AxKpaQQqCN3XBnNzb/5e0Gvd9OaQsYkK574LVI57v/EqqPfIm/mC7jYbxaPNrhvT5AF+Yzwyizg=="
+      "integrity": "sha512-E4fDUF4fbu9AxKpaQQqCN3XBnNzb/5e0Gvd9OaQsYkK574LVI57v/EqqPfIm/mC7jYbxaPNrhvT5AF+Yzwyizg==",
+      "dev": true
     },
     "@hapi/address": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@zenika/evoli-css",
   "version": "0.2.4",
-  "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.8.2"
-  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
@@ -39,6 +36,7 @@
     "singleQuote": true
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^5.8.2",
     "bulma": "^0.7.5",
     "eslint-config-prettier": "^4.3.0",
     "eslint-config-standard": "^12.0.0",

--- a/src/catalog/Main/scenes/Element/scenes/Icon/Icon.jsx
+++ b/src/catalog/Main/scenes/Element/scenes/Icon/Icon.jsx
@@ -9,6 +9,7 @@ const Icon = () => (
   <div>
     <h2>Icon</h2>
     <Figma nodeId="4%253A176" />
+    Font Awesome needs to be installed for icons to work.
     <IconNormal />
     <IconColors />
     <IconSizes />

--- a/src/library/index.scss
+++ b/src/library/index.scss
@@ -7,4 +7,3 @@
 @import './table.scss';
 @import './accordion.scss';
 @import '../../node_modules/bulma/bulma.sass';
-@import '../../node_modules/@fortawesome/fontawesome-free/css/all.css';


### PR DESCRIPTION

Evoli does not need Font Awesome to work fine. It needs it only for icons. If the app needs icon it can import font awesome as its own dependency.